### PR TITLE
Feat/plotting function

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This project provides two different commands:
 
 1. `ic` prints the line, file name, function name, name of variable and value.
 2. `ict` prints all the call tree.
+3. The `icp` and `ictp` variants just print a message string, with similar line preambles.
 
 The usage in both cases is the same:
 

--- a/src/ic.sh
+++ b/src/ic.sh
@@ -12,7 +12,12 @@ ic () {
     echo "(${BASH_SOURCE[1]},${FUNCNAME[1]}) ${BASH_LINENO[0]}: $1 - ${!tmp}"
 }
 
-# print full call tree
+# print file, function name, line, and message string
+icp () {
+    echo "(${BASH_SOURCE[1]},${FUNCNAME[1]}) ${BASH_LINENO[0]}: $1"
+}
+
+# print full call tree and variable and its value
 ict () {
     local tmp="${1}[@]"
     for((i=${#BASH_SOURCE[@]}-2;i>=0;i--));
@@ -20,4 +25,13 @@ ict () {
         echo -n "(${BASH_SOURCE[$i+1]},${FUNCNAME[$i+1]}) ${BASH_LINENO[$i]}: "
     done
     echo "$1 - ${!tmp}"
+}
+
+# print full call tree and message string
+ictp () {
+    for((i=${#BASH_SOURCE[@]}-2;i>=0;i--));
+    do
+        echo -n "(${BASH_SOURCE[$i+1]},${FUNCNAME[$i+1]}) ${BASH_LINENO[$i]}: "
+    done
+    echo "$1"
 }


### PR DESCRIPTION
Printing "normal" message strings alongside ```ic``` output looks a bit weird, as there is no "line preamble". So I just added a couple of variants of the ```ic``` and ```ict``` functions, named (unsurprisingly) ```icp``` (```ic``` normal **p**rint) and ```ictp``` (```ict``` normal **p**rint) to be used alongside.